### PR TITLE
Memperbaiki bug glDrawArrays: attempt to access out of range vertices

### DIFF
--- a/main.js
+++ b/main.js
@@ -491,13 +491,13 @@ function main()
 		rightGL.uniformMatrix4fv(matrixR, false, new Float32Array(mov_matrixR));
 		
 		leftGL.clear(leftGL.COLOR_BUFFER_BIT | leftGL.DEPTH_BUFFER_BIT);
-		leftGL.drawArrays(leftGL.TRIANGLES, 0, leftVertices.length);
+		leftGL.drawArrays(leftGL.TRIANGLES, 0, leftVertices.length / 6);
 		leftGL.enable(leftGL.DEPTH_TEST);
 		leftGL.viewport(0, (leftGL.canvas.height - leftGL.canvas.width)/2, leftGL.canvas.width, leftGL.canvas.width);
 		leftGL.clearColor(0.5, 0.5, 0.5, 0.9);
 
 		rightGL.clear(rightGL.COLOR_BUFFER_BIT | rightGL.DEPTH_BUFFER_BIT);
-		rightGL.drawArrays(rightGL.TRIANGLES, 0, rightVertices.length);
+		rightGL.drawArrays(rightGL.TRIANGLES, 0, rightVertices.length / 6);
 		rightGL.enable(rightGL.DEPTH_TEST);
 		rightGL.viewport(0, (leftGL.canvas.height - leftGL.canvas.width)/2, rightGL.canvas.width, rightGL.canvas.width);
 		rightGL.clearColor(0.5, 0.5, 0.5, 0.9);


### PR DESCRIPTION
Memperbaiki bug glDrawArrays: attempt to access out of range vertices yang terjadi pada beberapa browser dengan menambahkan pembagi sesuai jumlah elemen atribut verteks (dalam hal ini 6 buah: 3 posisi, 3 warna).
<img width="1283" alt="Screenshot 2020-06-01 10 58 32" src="https://user-images.githubusercontent.com/3130749/83375026-beb4f000-a3f7-11ea-97b0-bf27a7fb0eec.png">
